### PR TITLE
bump version for unit tests and remove unnecessary package references

### DIFF
--- a/HL7lite.Test/HL7lite.Test.csproj
+++ b/HL7lite.Test/HL7lite.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>1.1.6</ReleaseVersion>

--- a/src/HL7lite.csproj
+++ b/src/HL7lite.csproj
@@ -39,11 +39,4 @@
 	<ItemGroup>
 		<None Include="../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="System.Runtime" Version="4.3.0" />
-		<PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.Linq" Version="4.3.0" />
-		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-	</ItemGroup>
 </Project>


### PR DESCRIPTION
Would like to suggest a few tweaks to the HL7Lite library in small increments, starting with dotnet version and the Visual Studio warning