### PR TITLE
Make ParseMessage validation optional via bool parameter

### DIFF
--- a/HL7lite.Test/AutoCreateElementsTests.cs
+++ b/HL7lite.Test/AutoCreateElementsTests.cs
@@ -18,7 +18,7 @@ ZZ1|1|A|2^1";
             Message message = new Message(msg1);
             message.ParseMessage();
 
-            message.DefaultSegment("ZZ1").EnsureField(5).Value = "X";            
+            message.DefaultSegment("ZZ1").EnsureField(5).Value = "X";
 
             Assert.Equal("X", message.GetValue("ZZ1.5"));
         }
@@ -154,6 +154,23 @@ ZZ1|1|ID1|abc\R\^def";
             Assert.Equal("A", message.GetValue("ZZ1.3"));
             Assert.Equal("1", message.GetValue("ZZ1.2.2"));
 
+        }
+
+        /// <summary>These are invalid HL7 messages due to missing fields, but examples
+        /// of allowing the "ParseMessage" to be less opinionated and allow some sloppy
+        /// HL7 text</summary>
+        [Theory]
+        [InlineData("MSH|^~\\&|")]
+        [InlineData("MSH")]
+        [InlineData("EVN")]
+        public void LessOpinionatedParserWorks(string exampleBadHl7)
+        {
+            Message message = new Message(exampleBadHl7);
+            message.ParseMessage(false, false);
+
+            var output = message.SerializeMessage(false);
+
+            Assert.StartsWith(exampleBadHl7, output);
         }
     }
 }

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -57,15 +57,17 @@ namespace HL7lite
         /// <summary>
         /// Parse the HL7 message in text format, throws HL7Exception if error occurs
         /// </summary>
-        /// <param name="serializeCheck">If true (default) the message wil be serialized back to a string and compared with the original (throws if not eq)</param>
-        /// <exception>fails with an exception wheren parsing isn't succesful</exception>
-        public void ParseMessage(bool serializeCheck = true)
+        /// <param name="serializeCheck">If true (default) the message will be serialized back to a string and compared with the original (throws if not eq)</param>
+        /// <param name="validate">If true (default) the message will be validated for required HL7 entries</param>
+        /// <exception>fails with an exception where parsing isn't successful</exception>
+        public void ParseMessage(bool serializeCheck = true, bool validate = true)
         {
             // domibies 2 april 2021 : this method used to return a boolean, which was confusing (caller had to filter & exceptions AND check return value)
             // now it just throws HL7Exception on any failure
             try
             {
-                this.validateMessage();
+                if(validate)
+                    this.validateMessage();
             }
             catch (HL7Exception ex)
             {


### PR DESCRIPTION
Add optional parameter (default is not a breaking change) so that some "bad" HL7 messages can still be parsed
Ref #6 